### PR TITLE
Adds fallback case if insertRule fails

### DIFF
--- a/src/lib/css/createCache.js
+++ b/src/lib/css/createCache.js
@@ -52,12 +52,23 @@ const createCache = () => {
     if (isServer) {
       serverStyles += rule;
     } else {
-      if (isDevelopment) {
+      const insertTag = () => {
         const atomStyleElement = document.createElement('style');
         document.head.appendChild(atomStyleElement);
         atomStyleElement.innerHTML = rule;
+      };
+
+      if (isDevelopment) {
+        insertTag();
       } else {
-        styleElement.sheet.insertRule(rule, styleElement.sheet.cssRules.length);
+        try {
+          styleElement.sheet.insertRule(
+            rule,
+            styleElement.sheet.cssRules.length
+          );
+        } catch (error) {
+          insertTag();
+        }
       }
     }
     identifiers[hash].commit = true;


### PR DESCRIPTION
Unlike regular css `insertRule` throws an error if it doesn't understand certain rules.
Webkit browsers break on `.mi2j6hw::-moz-focus-inner{border:0}` so this adds a case to fallback to using regular style tags if insertRule fails.